### PR TITLE
(fzs-29) Avisos e notificações

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Quicksand:wght@300..700&display=swap" rel="stylesheet">
-    <title>Vite + React + TS</title>
+    <title>Checkpoint - marcação de ponto online</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import LoginPage from './pages/Employee/LoginPage'
 import MarkingPage from './pages/Employee/MarkingPage'
 import DayPage from './pages/Employee/DayPage'
 import JustificationPage from './pages/Employee/JustificationPage'
+import NotificationsPage from './pages/Employee/NotificationsPage'
 
 function App() {
 	/**
@@ -23,6 +24,9 @@ function App() {
 			</Routes>
 			<Routes>
 				<Route path="/abono" element={<JustificationPage />} />
+			</Routes>
+			<Routes>
+				<Route path="/notificacoes" element={<NotificationsPage />} />
 			</Routes>
 		</BrowserRouter>
 	)

--- a/src/components/BottomBar.tsx
+++ b/src/components/BottomBar.tsx
@@ -7,7 +7,7 @@ import { RootState } from '../redux/store'
 
 function BottomBar() {
     const [isMenuOpen, setIsMenuOpen] = useState(false)
-    const notifications = useSelector((state: RootState) => state.notifications.count)
+    const { count } = useSelector((state: RootState) => state.notifications)
 
     return (
         <nav className='main-func-color w-full h-[62px] fixed bottom-0 flex main-white-text items-center justify-evenly'>
@@ -17,11 +17,11 @@ function BottomBar() {
                 </Link>
             </span>
             <span className="relative">
-                <Link to={'/'}>
+                <Link to={'/notificacoes'}>
                     <i className="fa-solid fa-bell text-2xl"></i>
-                    {notifications > 0 && (
+                    { count > 0 && (
                         <span className="absolute top-[-5px] right-[-5px] bg-red-600 text-white text-xs rounded-full px-2">
-                            {notifications}
+                            { count }
                         </span>
                     )}
                 </Link>

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -23,7 +23,7 @@ function Modal({ title, children, onClose, onSubmit }: ModalProp) {
 
     return (
         <div className='bg-[rgba(0,0,0,0.8)] fixed top-0 left-0 w-screen h-screen z-50 flex justify-center items-center' onClick={handleBackgroundClick}>
-            <div className='min-w-[80%] bg-white px-4 py-8 rounded'>
+            <div className='max-w-[80%] w-[80%] bg-white px-4 py-8 rounded'>
                 <h2 className='text-2xl mb-4'>
                     { title }
                 </h2>

--- a/src/components/NotificationCard.tsx
+++ b/src/components/NotificationCard.tsx
@@ -5,11 +5,12 @@ type NotificationCardProp = {
     message: string
     date: string
     color: string
+    openModal: () => void
 }
 
-function NotificationCard({ title, message, date, color }: NotificationCardProp) {
+function NotificationCard({ title, message, date, color, openModal }: NotificationCardProp) {
     return (
-        <div className={`w-full bg-red-300 rounded-xl p-3 max-h-[100px] h-[100px] ${color}`}>
+        <div className={`w-full bg-red-300 rounded-xl p-3 max-h-[100px] h-[100px] ${color}`} onClick={openModal}>
             <div className='flex justify-between'>
                 <p className='font-semibold mb-2'>
                     Pedido de { title }

--- a/src/components/NotificationCard.tsx
+++ b/src/components/NotificationCard.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+
+type NotificationCardProp = {
+    title: string
+    message: string
+    date: string
+    color: string
+}
+
+function NotificationCard({ title, message, date, color }: NotificationCardProp) {
+    return (
+        <div className={`w-full bg-red-300 rounded-xl p-3 max-h-[100px] h-[100px] ${color}`}>
+            <div className='flex justify-between'>
+                <p className='font-semibold mb-2'>
+                    Pedido de { title }
+                </p>
+
+                <p className='text-sm font-light'>
+                    { date }
+                </p>
+            </div>
+
+            <p className='text-sm line-clamp-2'>
+                {message}
+            </p>
+        </div>
+    )
+}
+
+export default NotificationCard

--- a/src/pages/Employee/MarkingPage.tsx
+++ b/src/pages/Employee/MarkingPage.tsx
@@ -88,8 +88,8 @@ function MarkingPage() {
                         <p>Registrar início: 02h:08min</p>
                     </div>
 
-                    <div className='text-white'>
-                        <button className='main-func-color px-8 py-2 rounded-lg mr-4 cursor-pointer'>
+                    <div className='text-white w-full flex justify-between'>
+                        <button className='main-func-color px-8 py-2 rounded-lg cursor-pointer'>
                             Confirmar
                         </button>
 

--- a/src/pages/Employee/NotificationsPage.tsx
+++ b/src/pages/Employee/NotificationsPage.tsx
@@ -1,12 +1,30 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useSelector } from 'react-redux'
 import { RootState } from '../../redux/store'
 import TemplateWithTitle from './TemplateWithTitle'
 import NotificationCard from '../../components/NotificationCard'
 import { formatDate } from '../../utils/formatter'
+import Modal from '../../components/Modal'
+import { Notification } from '../../redux/slices/notificationSlice'
 
 function NotificationsPage() {
     const { notifications } = useSelector((state: RootState) => state.notifications)
+    const [isModalVisible, setIsModalVisible] = useState<boolean>(false)
+    const [selectedNotification, setSelectedNotification] = useState<null | {
+        tipo: string
+        mensagem: string
+        criadoEm: string
+    }>(null)
+
+    const openModal = (notification: Notification): void => {
+        setSelectedNotification(notification)
+        setIsModalVisible(true)
+    }
+
+    const closeModal = (): void => {
+        setSelectedNotification(null)
+        setIsModalVisible(false)
+    }
     
     return (
         <TemplateWithTitle title='Notificações'>
@@ -20,11 +38,22 @@ function NotificationsPage() {
                                 date={formatDate(notification.criadoEm)}
                                 // TODO: colocar uma cor diferente por tipo
                                 color={'main-green-color'}
+                                openModal={() => openModal(notification)}
                             />
                         </div>
                     ))
                 }
             </div>
+
+            {
+                isModalVisible &&
+                <Modal title={`Pedido de ${selectedNotification?.tipo}`} onClose={closeModal}>
+                    <div>
+                        <p className='mb-2'>{selectedNotification?.mensagem}</p>
+                        <p className='text-sm light-gray-text'>{formatDate(selectedNotification ? selectedNotification?.criadoEm : '')}</p>
+                    </div>
+                </Modal>
+            }
         </TemplateWithTitle>
     )
 }

--- a/src/pages/Employee/NotificationsPage.tsx
+++ b/src/pages/Employee/NotificationsPage.tsx
@@ -5,7 +5,8 @@ import TemplateWithTitle from './TemplateWithTitle'
 import NotificationCard from '../../components/NotificationCard'
 import { formatDate } from '../../utils/formatter'
 import Modal from '../../components/Modal'
-import { Notification } from '../../redux/slices/notificationSlice'
+import { markNotificationAsRead, Notification } from '../../redux/slices/notificationSlice'
+import { useDispatch } from 'react-redux'
 
 function NotificationsPage() {
     const { notifications } = useSelector((state: RootState) => state.notifications)
@@ -15,10 +16,18 @@ function NotificationsPage() {
         mensagem: string
         criadoEm: string
     }>(null)
+    const dispatch = useDispatch()
 
-    const openModal = (notification: Notification): void => {
+    const openModal = async (notification: Notification): Promise<void> => {
         setSelectedNotification(notification)
         setIsModalVisible(true)
+
+        try {
+            dispatch(markNotificationAsRead(notification.id))
+            console.log('Notificação lida')
+        } catch(err: unknown) {
+            console.error(err)
+        }
     }
 
     const closeModal = (): void => {
@@ -30,17 +39,19 @@ function NotificationsPage() {
         <TemplateWithTitle title='Notificações'>
             <div className='mt-5 w-full'>
                 {
-                    notifications.map(notification => (
-                        <div className='mb-3'>
-                            <NotificationCard 
-                                title={notification.tipo}
-                                message={notification.mensagem}
-                                date={formatDate(notification.criadoEm)}
-                                // TODO: colocar uma cor diferente por tipo
-                                color={'main-green-color'}
-                                openModal={() => openModal(notification)}
-                            />
-                        </div>
+                    notifications
+                        .filter(notification => !notification.lida)
+                        .map(notification => (
+                            <div className='mb-3'>
+                                <NotificationCard 
+                                    title={notification.tipo}
+                                    message={notification.mensagem}
+                                    date={formatDate(notification.criadoEm)}
+                                    // TODO: colocar uma cor diferente por tipo
+                                    color={'main-green-color'}
+                                    openModal={() => openModal(notification)}
+                                />
+                            </div>
                     ))
                 }
             </div>

--- a/src/pages/Employee/NotificationsPage.tsx
+++ b/src/pages/Employee/NotificationsPage.tsx
@@ -28,7 +28,7 @@ function NotificationsPage() {
     
     return (
         <TemplateWithTitle title='Notificações'>
-            <div className='mt-5'>
+            <div className='mt-5 w-full'>
                 {
                     notifications.map(notification => (
                         <div className='mb-3'>

--- a/src/pages/Employee/NotificationsPage.tsx
+++ b/src/pages/Employee/NotificationsPage.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { useSelector } from 'react-redux'
+import { RootState } from '../../redux/store'
+import TemplateWithTitle from './TemplateWithTitle'
+import NotificationCard from '../../components/NotificationCard'
+import { formatDate } from '../../utils/formatter'
+
+function NotificationsPage() {
+    const { notifications } = useSelector((state: RootState) => state.notifications)
+    
+    return (
+        <TemplateWithTitle title='Notificações'>
+            <div className='mt-5'>
+                {
+                    notifications.map(notification => (
+                        <div className='mb-3'>
+                            <NotificationCard 
+                                title={notification.tipo}
+                                message={notification.mensagem}
+                                date={formatDate(notification.criadoEm)}
+                                // TODO: colocar uma cor diferente por tipo
+                                color={'main-green-color'}
+                            />
+                        </div>
+                    ))
+                }
+            </div>
+        </TemplateWithTitle>
+    )
+}
+
+export default NotificationsPage

--- a/src/pages/Employee/OptionsPage.tsx
+++ b/src/pages/Employee/OptionsPage.tsx
@@ -1,12 +1,15 @@
 import React from 'react'
 import { Link } from 'react-router'
 import { motion } from 'framer-motion'
+import { useSelector } from 'react-redux'
+import { RootState } from '../../redux/store'
 
 type OptionsPageProp = {
     onClose: () => void
 }
 
 function OptionsPage({ onClose }: OptionsPageProp) {
+    const { count } = useSelector((state: RootState) => state.notifications)
     return (
         <motion.div
             className='min-h-screen min-w-screen bg-white fixed top-0 left-0 main-black-text'
@@ -36,11 +39,21 @@ function OptionsPage({ onClose }: OptionsPageProp) {
                         </Link>
                     </p>
 
-                    <p className='flex mb-3'>
-                        <Link>
+                    <p className='flex mb-3 justify-between'>
+                        <Link to={'/notificacoes'}>
                             <i className="fa-solid fa-bell mr-2 main-red-text"></i>
                             <span>Notificações</span>
                         </Link>
+
+                        <p>
+                            {
+                                count > 0 && (
+                                    <span className='text-white text-xs rounded-full px-2 py-1 bg-red-600'>
+                                        { count }
+                                    </span>
+                                )
+                            }
+                        </p>
                     </p>
 
                     <p className='flex mb-3'>

--- a/src/pages/Employee/Template.tsx
+++ b/src/pages/Employee/Template.tsx
@@ -34,7 +34,7 @@ function Template({ children }: templateProps) {
     }, [count])
 
     return (
-        <div className='min-w-screen' style={{ minHeight: 'calc(100vh + 162px)' }}>
+        <div className='min-w-screen pb-[62px]' style={{ minHeight: 'calc(100vh + 162px)' }}>
             <TopBar/>
             <div className='w-[90%] flex flex-col items-center' style={{margin: "0 auto"}}>
                 { children }

--- a/src/pages/Employee/Template.tsx
+++ b/src/pages/Employee/Template.tsx
@@ -1,9 +1,10 @@
-import React, { ReactNode, useEffect } from 'react'
+import React, { ReactNode, use, useEffect } from 'react'
 import TopBar from '../../components/TopBar'
 import BottomBar from '../../components/BottomBar'
 import { ToastContainer } from 'react-toastify'
-import { useDispatch } from 'react-redux'
+import { useSelector, useDispatch } from 'react-redux'
 import { fetchUnreadNotifications } from '../../redux/slices/notificationSlice'
+import { RootState } from '../../redux/store'
 
 type templateProps = {
     children?: ReactNode
@@ -11,6 +12,7 @@ type templateProps = {
 
 function Template({ children }: templateProps) {
     const dispatch = useDispatch()
+    const { count } = useSelector((state: RootState) => state.notifications)
 
     useEffect(() => {
         // TODO: colocar o id do colaborador logado
@@ -22,6 +24,15 @@ function Template({ children }: templateProps) {
             dispatch({ type: 'websocket/disconnect' })
         }
     }, [dispatch])
+
+    useEffect(() => {
+        if (count > 0) {
+            document.title = `(${count}) Checkpoint`
+        } else {
+            document.title = "Checkpoint - marcação de ponto online"
+        }
+    }, [count])
+
     return (
         <div className='min-w-screen' style={{ minHeight: 'calc(100vh + 162px)' }}>
             <TopBar/>

--- a/src/redux/slices/notificationSlice.ts
+++ b/src/redux/slices/notificationSlice.ts
@@ -27,6 +27,14 @@ export const fetchUnreadNotifications = createAsyncThunk(
     }
 )
 
+export const markNotificationAsRead = createAsyncThunk(
+    'notifications/markAsRead',
+    async (notificationId: number) => {
+        const response = await api.put(`/colaborador/notificacao/${notificationId}`)
+        return response.data
+    }
+)
+
 const notificationSlice = createSlice({
     name: 'notifications',
     initialState,
@@ -40,9 +48,17 @@ const notificationSlice = createSlice({
         }
     },
     extraReducers: (builder) => {
-        builder.addCase(fetchUnreadNotifications.fulfilled, (state, action) => {
+        builder
+        .addCase(fetchUnreadNotifications.fulfilled, (state, action) => {
             state.notifications = action.payload
             state.count = action.payload.length
+        })
+        .addCase(markNotificationAsRead.fulfilled, (state, action) => {
+            const updatedNotification = action.payload;
+            state.notifications = state.notifications.map(n =>
+                n.id === updatedNotification.id ? { ...n, lida: true } : n
+            );
+            state.count = state.notifications.filter(n => !n.lida).length;
         })
     }
 })

--- a/src/redux/slices/notificationSlice.ts
+++ b/src/redux/slices/notificationSlice.ts
@@ -1,7 +1,7 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit'
 import api from '../../services/api'
 
-interface Notification {
+export interface Notification {
     id: number
     mensagem: string
     lida: boolean

--- a/src/redux/slices/notificationSlice.ts
+++ b/src/redux/slices/notificationSlice.ts
@@ -1,19 +1,29 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit'
+import api from '../../services/api'
+
+interface Notification {
+    id: number
+    mensagem: string
+    lida: boolean
+    criadoEm: string
+    tipo: string
+}
 
 interface NotificationState {
     count: number
+    notifications: Notification[]
 }
 
 const initialState: NotificationState = {
     count: 0,
+    notifications: []
 }
 
 export const fetchUnreadNotifications = createAsyncThunk(
     'notifications/fetchUnread',
     async (colaboradorId: number) => {
-        const response = await fetch(`http://localhost:8080/colaborador/notificacoes/${colaboradorId}`)
-        const data = await response.json()
-        return data.length
+        const response = await api.get(`/colaborador/notificacoes/${colaboradorId}`)
+        return response.data
     }
 )
 
@@ -26,11 +36,13 @@ const notificationSlice = createSlice({
         },
         reset: (state) => {
             state.count = 0
+            state.notifications = []
         }
     },
     extraReducers: (builder) => {
         builder.addCase(fetchUnreadNotifications.fulfilled, (state, action) => {
-            state.count = action.payload
+            state.notifications = action.payload
+            state.count = action.payload.length
         })
     }
 })

--- a/src/utils/formatter.ts
+++ b/src/utils/formatter.ts
@@ -1,4 +1,4 @@
-const formatDate = (val: Date): string => {
+const formatDate = (val: Date | string): string => {
     return new Date(val).toLocaleDateString('pt-BR')
 }
 


### PR DESCRIPTION
# O que foi feito
- Adicionado página para visualização de avisos e notificações
- Adicinado badge de notificação no menu
- Adicionado badge de notificação no titulo da página

# O porquê
- Para completar a task fzs-29, sobre a interface de aviso de atraso

# O que mudou
- Mudança da lógica do slice de notificações para ter mais um reducer para a marcação da notificação como lida
- Agora ao clicar sobre uma notificação, abrirá um modal com mais detalhes e a ela será marcada como lida
- Badge de notificação aparece no título da página, caso haja notificação
- Badge de notificação também aparece no menu ao lado do texto